### PR TITLE
revoke and reissue of same permit_no, otherwise create new.

### DIFF
--- a/issuer_controller/config/local/services.yml
+++ b/issuer_controller/config/local/services.yml
@@ -38,6 +38,8 @@ issuers:
         type:
           input: my-registration.bcgov-mines-permitting
           from: value
+      cardinality_fields:
+        - permit_no
       mapping:
       - model: attribute
         fields:

--- a/issuer_controller/config/openshift/services.yml
+++ b/issuer_controller/config/openshift/services.yml
@@ -34,6 +34,8 @@ issuers:
         type:
           input: registration.registries.ca
           from: value
+      cardinality_fields:
+        - permit_no
       mapping:
       - model: attribute
         fields:


### PR DESCRIPTION
Signed-off-by: Jason Sy <jasyrotuck@gmail.com>

# Description
Currently anytime our mines-permitting-issuer issues credentials to the same business number. It will always overwrite, the business need is many permit_no's to each business. So i've configured it to match. 

It's possible that we need permit_amendments, but ideally the business catches up to this layout before we need to publish amendments. 