### PR TITLE
Make Cred Def a standalone operation

### DIFF
--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/api/CredDefAPI.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/api/CredDefAPI.java
@@ -1,0 +1,28 @@
+package org.hyperledger.bpa.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hyperledger.aries.api.creddef.CredentialDefinition;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CredDefAPI {
+    private String id;
+
+    private String schemaId;
+
+    private String tag;
+
+    public static CredDefAPI from(CredentialDefinition o) {
+        return CredDefAPI
+                .builder()
+                .id(o.getId())
+                .schemaId(o.getSchemaId())
+                .tag(o.getTag())
+                .build();
+    }
+}

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/api/aries/AriesCredential.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/api/aries/AriesCredential.java
@@ -18,6 +18,7 @@
 package org.hyperledger.bpa.api.aries;
 
 import lombok.*;
+import org.hyperledger.bpa.model.IssuedCredential;
 import org.hyperledger.bpa.model.MyCredential;
 
 import java.util.Map;
@@ -53,6 +54,17 @@ public class AriesCredential {
                 .state(c.getState())
                 .isPublic(c.getIsPublic())
                 .issuer(c.getIssuer())
+                .connectionId(c.getConnectionId())
+                .label(c.getLabel());
+    }
+
+    public static AriesCredentialBuilder fromIssuedCredential(@NonNull IssuedCredential c, @NonNull String myDid) {
+        return AriesCredential
+                .builder()
+                .id(c.getId())
+                .issuedAt(c.getIssuedAt() != null ? c.getIssuedAt().toEpochMilli() : null)
+                .state(c.getState())
+                .issuer(myDid)
                 .connectionId(c.getConnectionId())
                 .label(c.getLabel());
     }

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/PartnerController.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/PartnerController.java
@@ -150,7 +150,7 @@ public class PartnerController {
      */
     @Post
     public HttpResponse<PartnerAPI> addPartner(@Body AddPartnerRequest partner) {
-        //wrong did
+        // wrong did
         return HttpResponse.created(pm.addPartnerFlow(partner.getDid(), partner.getAlias()));
     }
 

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/WalletController.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/WalletController.java
@@ -193,4 +193,5 @@ public class WalletController {
         }
         return HttpResponse.notFound();
     }
+
 }

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/admin/CreateCredDefRequest.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/admin/CreateCredDefRequest.java
@@ -1,0 +1,18 @@
+package org.hyperledger.bpa.controller.api.admin;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class CreateCredDefRequest {
+    private String schemaId;
+
+    private String tag;
+
+    private int revocationRegistrySize;
+
+    private boolean supportRevocation;
+}

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/admin/CreateSchemaRequest.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/admin/CreateSchemaRequest.java
@@ -25,11 +25,16 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 public class CreateSchemaRequest {
+    // BPA fields
     private String schemaLabel;
 
+    private String defaultAttributeName;
+
+    // aries fields...
     private String schemaName;
 
     private String schemaVersion;
 
     private List<String> attributes;
+
 }

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/partner/IssueCredentialSendRequest.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/controller/api/partner/IssueCredentialSendRequest.java
@@ -1,0 +1,17 @@
+package org.hyperledger.bpa.controller.api.partner;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class IssueCredentialSendRequest {
+    private String schemaId;
+    private String credentialDefinitionId;
+    @JsonRawValue
+    @Schema(example = "{}")
+    private JsonNode document;
+}

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/PartnerManager.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/PartnerManager.java
@@ -43,7 +43,8 @@ import java.util.UUID;
 
 @Singleton
 public class PartnerManager {
-    @Inject private ApplicationEventPublisher eventPublisher;
+    @Inject
+    private ApplicationEventPublisher eventPublisher;
 
     @Value("${bpa.did.prefix}")
     private String ledgerPrefix;
@@ -105,7 +106,7 @@ public class PartnerManager {
                 .setState("requested");
         Partner result = repo.save(partner); // save before creating the connection
         if (did.startsWith(ledgerPrefix) && lookupP.getAriesSupport()) {
-            //wrong did
+            // wrong did
             cm.createConnection(did, connectionLabel, alias);
         } else if (lookupP.getAriesSupport()) {
             cm.createConnection(lookupP.getDidDocAPI(), connectionLabel, alias);

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/StartupTasks.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/StartupTasks.java
@@ -26,6 +26,7 @@ import io.micronaut.scheduling.annotation.Async;
 import lombok.extern.slf4j.Slf4j;
 import org.hyperledger.aries.AriesClient;
 import org.hyperledger.bpa.impl.activity.VPManager;
+import org.hyperledger.bpa.impl.aries.CredentialDefinitionService;
 import org.hyperledger.bpa.impl.aries.PartnerCredDefLookup;
 import org.hyperledger.bpa.impl.aries.SchemaService;
 import org.hyperledger.bpa.impl.mode.indy.IndyStartupTasks;
@@ -63,6 +64,9 @@ public class StartupTasks {
     PartnerCredDefLookup credLookup;
 
     @Inject
+    CredentialDefinitionService credentialDefinitionService;
+
+    @Inject
     VPManager vpMgmt;
 
     @Inject
@@ -96,6 +100,7 @@ public class StartupTasks {
                 });
 
         credLookup.lookupTypesForAllPartnersAsync();
+        credentialDefinitionService.refreshSchemaCredDefsAsync();
     }
 
     private void checkModeChange() {

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/CredentialDefinitionService.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/CredentialDefinitionService.java
@@ -90,6 +90,16 @@ public class CredentialDefinitionService {
         return myCredDefs;
     }
 
+    public Optional<CredentialDefinition> getCredentialDefinition(@NonNull String id) {
+        Optional<CredentialDefinition> result = null;
+        try {
+            result = ac.credentialDefinitionsGetById(id);
+        } catch (IOException e) {
+            log.error("aca-py not reachable", e);
+        }
+        return result;
+    }
+
     private List<String> getCreatedCredentialDefinitionIds() {
         List<String> result = null;
         try {
@@ -97,16 +107,6 @@ public class CredentialDefinitionService {
             if (created.isPresent()) {
                 result = created.get().getCredentialDefinitionIds();
             }
-        } catch (IOException e) {
-            log.error("aca-py not reachable", e);
-        }
-        return result;
-    }
-
-    private Optional<CredentialDefinition> getCredentialDefinition(@NonNull String id) {
-        Optional<CredentialDefinition> result = null;
-        try {
-            result = ac.credentialDefinitionsGetById(id);
         } catch (IOException e) {
             log.error("aca-py not reachable", e);
         }

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/CredentialDefinitionService.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/impl/aries/CredentialDefinitionService.java
@@ -1,0 +1,123 @@
+package org.hyperledger.bpa.impl.aries;
+
+import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.scheduling.annotation.Async;
+import io.micronaut.scheduling.annotation.Scheduled;
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.hyperledger.aries.AriesClient;
+import org.hyperledger.aries.api.creddef.CredentialDefinition;
+import org.hyperledger.aries.api.creddef.CredentialDefinition.*;
+import org.hyperledger.bpa.api.CredDefAPI;
+import org.hyperledger.bpa.api.aries.SchemaAPI;
+import org.hyperledger.bpa.model.BPASchema;
+import org.hyperledger.bpa.repository.SchemaRepository;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.*;
+
+@Slf4j
+@Singleton
+public class CredentialDefinitionService {
+
+    @Inject
+    @Setter(AccessLevel.PACKAGE)
+    SchemaRepository schemaRepo;
+
+    @Inject
+    AriesClient ac;
+
+    private Map<String, CredDefAPI> mySchemaCredDefs = new HashMap<>();
+    private List<CredDefAPI> myCredDefs = new ArrayList<>();
+
+    public String createCredentialDefinition(@NonNull String schemaId, String tag, int revocationRegistrySize,
+            boolean supportRevocation) {
+        // do we need to force tag to be of a particular format (illegal chars etc)?
+        // do we need to validate revocation size?
+        String result = null;
+        CredentialDefinitionRequest creddef = CredentialDefinitionRequest.builder()
+                .revocationRegistrySize(revocationRegistrySize)
+                .schemaId(schemaId)
+                .supportRevocation(supportRevocation)
+                .tag(tag)
+                .build();
+        try {
+            Optional<CredentialDefinitionResponse> creddefResponse = ac.credentialDefinitionsCreate(creddef);
+            if (creddefResponse.isPresent()) {
+                result = creddefResponse.get().getCredentialDefinitionId();
+                log.debug("Credential Definition created: {}", result);
+                refreshSchemaCredDefsAsync();
+            } else {
+                log.error("Credential Definition not created.");
+            }
+        } catch (IOException e) {
+            log.error("aca-py not reachable", e);
+        }
+        return result;
+    }
+
+    @Scheduled(fixedRate = "10m", initialDelay = "10m")
+    public void refreshSchemaCredDefs() {
+        myCredDefs = getMyCredentialDefinitions();
+        mySchemaCredDefs = new HashMap<>();
+        schemaRepo.findAll().forEach((s) -> myCredDefs.stream()
+                .filter(x -> x.getSchemaId().contentEquals(s.getSeqNo().toString())).findFirst()
+                .ifPresent(c -> mySchemaCredDefs.put(s.getSchemaId(), c)));
+    }
+
+    @Async
+    public void refreshSchemaCredDefsAsync() {
+        refreshSchemaCredDefs();
+    }
+
+    public Map<String, CredDefAPI> getSchemaCredDefs() {
+        return mySchemaCredDefs;
+    }
+
+    public CredDefAPI getSchemaCredDef(String schemaId) {
+        try {
+            return mySchemaCredDefs.get(schemaId);
+        } catch (NullPointerException e) {
+            return null;
+        }
+    }
+
+    public List<CredDefAPI> getCredDefs() {
+        return myCredDefs;
+    }
+
+    private List<String> getCreatedCredentialDefinitionIds() {
+        List<String> result = null;
+        try {
+            Optional<CredentialDefinition.CredentialDefinitionsCreated> created = ac.credentialDefinitionsCreated(null);
+            if (created.isPresent()) {
+                result = created.get().getCredentialDefinitionIds();
+            }
+        } catch (IOException e) {
+            log.error("aca-py not reachable", e);
+        }
+        return result;
+    }
+
+    private Optional<CredentialDefinition> getCredentialDefinition(@NonNull String id) {
+        Optional<CredentialDefinition> result = null;
+        try {
+            result = ac.credentialDefinitionsGetById(id);
+        } catch (IOException e) {
+            log.error("aca-py not reachable", e);
+        }
+        return result;
+    }
+
+    private List<CredDefAPI> getMyCredentialDefinitions() {
+        List<CredDefAPI> result = new ArrayList<>();
+        this.getCreatedCredentialDefinitionIds().stream()
+                .forEach((id) -> this.getCredentialDefinition(id).ifPresent(c -> result.add(CredDefAPI.from(c))));
+        return result;
+    }
+
+}

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/IssuedCredential.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/model/IssuedCredential.java
@@ -1,0 +1,86 @@
+/*
+  Copyright (c) 2020 - for information on the respective copyright owner
+  see the NOTICE file and/or the repository at
+  https://github.com/hyperledger-labs/business-partner-agent
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package org.hyperledger.bpa.model;
+
+import io.micronaut.data.annotation.AutoPopulated;
+import io.micronaut.data.annotation.TypeDef;
+import io.micronaut.data.model.DataType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import org.hyperledger.bpa.api.CredentialType;
+
+import javax.annotation.Nullable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * MyCredential is a credential that is received via aries. It is NOT to be
+ * confused with the verifiable credential (VC) that is part of the public
+ * profile. When a aries credential is made public it will become a VC as part
+ * of the public profile.
+ *
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Accessors(chain = true)
+@Data
+@Entity
+public class IssuedCredential {
+
+    @Id
+    @AutoPopulated
+    private UUID id;
+
+    @Nullable
+    private Instant issuedAt;
+
+    @Nullable
+    private CredentialType type;
+
+    @Nullable
+    private String connectionId;
+
+    private String state;
+
+    private String threadId;
+
+    private String credentialExchangeId;
+
+    private String schemaId;
+
+    private String credentialDefinitionId;
+
+    @Nullable
+    private String label;
+
+    @Nullable
+    @TypeDef(type = DataType.JSON)
+    private Map<String, Object> credential;
+
+    @Nullable
+    @TypeDef(type = DataType.JSON)
+    private Map<String, Object> credentialPreview;
+
+}

--- a/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/IssuedCredentialRepository.java
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/java/org/hyperledger/bpa/repository/IssuedCredentialRepository.java
@@ -1,0 +1,49 @@
+/*
+  Copyright (c) 2020 - for information on the respective copyright owner
+  see the NOTICE file and/or the repository at
+  https://github.com/hyperledger-labs/business-partner-agent
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package org.hyperledger.bpa.repository;
+
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.Query;
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+import org.hyperledger.bpa.model.IssuedCredential;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+public interface IssuedCredentialRepository extends CrudRepository<IssuedCredential, UUID> {
+
+    void updateState(@Id UUID id, String state);
+
+    void updateLabel(@Id UUID id, String label);
+
+    Number updateByConnectionId(String id, @Nullable String connectionId);
+
+    Optional<IssuedCredential> findByThreadId(String threadId);
+
+    List<IssuedCredential> findByConnectionId(String connectionId);
+
+    List<IssuedCredential> findBySchemaIdAndCredentialDefinitionId(String schemaId, String credentialDefinitionId);
+
+    Long countByStateEquals(String state);
+
+}

--- a/services/bb-pacman/backend/business-partner-agent/src/main/resources/databasemigrations/V1.10__issued-credentials-table.sql
+++ b/services/bb-pacman/backend/business-partner-agent/src/main/resources/databasemigrations/V1.10__issued-credentials-table.sql
@@ -1,0 +1,15 @@
+
+CREATE TABLE issued_credential (
+   id uuid PRIMARY KEY,
+   issued_at timestamp without time zone,
+   type character varying(255),
+   connection_id character varying(255) NOT NULL,
+   state character varying(255) NOT NULL,
+   thread_id character varying(255) NOT NULL,
+   credential_exchange_id character varying(255) NOT NULL,
+   schema_id character varying(255),
+   label character varying(255),
+   credential_definition_id character varying(255),
+   credential jsonb,
+   credential_preview jsonb
+);

--- a/services/bb-pacman/frontend/src/components/Credential.vue
+++ b/services/bb-pacman/frontend/src/components/Credential.vue
@@ -2,7 +2,7 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -42,9 +42,7 @@
         <v-text-field
           v-if="intDoc.issuedAt"
           label="Issued at"
-          :placeholder="
-            $options.filters.moment(intDoc.issuedAt, 'YYYY-MM-DD HH:mm')
-          "
+          :value="$options.filters.moment(intDoc.issuedAt, 'YYYY-MM-DD HH:mm')"
           disabled
           outlined
           dense

--- a/services/bb-pacman/frontend/src/components/IssuedCredentialList.vue
+++ b/services/bb-pacman/frontend/src/components/IssuedCredentialList.vue
@@ -1,0 +1,116 @@
+<!--
+ Copyright (c) 2020 - for information on the respective copyright owner
+ see the NOTICE file and/or the repository at
+ https://github.com/hyperledger-labs/organizational-agent
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <v-data-table
+    :hide-default-footer="credentialsWithIndex.length < 10"
+    v-model="selected"
+    :show-select="selectable"
+    :headers="headers"
+    :items="credentialsWithIndex"
+    :expanded.sync="expanded"
+    item-key="index"
+    :show-expand="expandable"
+    :sort-by="['createdDate']"
+    :sort-desc="[false]"
+    single-select
+    @click:row="openCredential"
+  >
+    <template v-slot:[`item.type`]="{ item }">
+      <div v-if="item.type === CredentialTypes.UNKNOWN.type">
+        {{ item.credentialDefinitionId | credentialTag | capitalize }}
+      </div>
+      <div v-else>
+        {{ item.typeLabel }}
+      </div>
+    </template>
+    <template v-slot:[`item.issuedAt`]="{ item }">
+      {{ item.issuedAt | moment("YYYY-MM-DD HH:mm") }}
+    </template>
+    <template v-slot:[`item.state`]="{ item }">
+      <v-icon
+        v-if="item.state == 'credential_acked'"
+        color="green"
+        >mdi-check</v-icon
+      >
+      <span v-else>
+        {{ item.state.replace("_", " ") }}
+      </span>
+    </template>
+    <template v-slot:expanded-item="{ headers, item }">
+      <td :colspan="headers.length">
+        <Credential
+          v-bind:document="item"
+          isReadOnly
+          showOnlyContent
+        ></Credential>
+      </td>
+    </template>
+  </v-data-table>
+</template>
+
+<script>
+import Credential from "@/components/Credential";
+import { CredentialTypes } from "../constants";
+import { issuedListHeaders } from "@/components/tableHeaders/PresentationListHeaders";
+
+export default {
+  props: {
+    credentials: Array,
+    selectable: {
+      type: Boolean,
+      default: false,
+    },
+    expandable: {
+      type: Boolean,
+      default: true,
+    },
+    headers: {
+      type: Array,
+      default: () => issuedListHeaders,
+    },
+  },
+  data: () => {
+    return {
+      selected: [],
+      CredentialTypes: CredentialTypes,
+      expanded: [],
+    };
+  },
+  computed: {
+    // Add an unique index, because elements do not have unique id
+    credentialsWithIndex: function () {
+      return this.credentials.map((creds, index) => ({
+        ...creds,
+        index: index + 1,
+      }));
+      // .map(credential => {
+      //   credential.verified = true
+      // })
+    },
+  },
+  methods: {
+    openCredential(item) {
+      if (item.state == "credential_acked") {
+        if (item.id) {
+          this.$router.push({
+            path: `issued/${item.id}`,
+            append: true,
+          });
+        }
+      } else {
+        // Do nothing for now. Presentation is not ready
+        // Need to fix Presentation.vue for unfinished presentations
+      }
+    },
+  },
+  components: {
+    Credential,
+  },
+};
+</script>

--- a/services/bb-pacman/frontend/src/components/tableHeaders/PartnerHeaders.js
+++ b/services/bb-pacman/frontend/src/components/tableHeaders/PartnerHeaders.js
@@ -2,7 +2,7 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 */
 

--- a/services/bb-pacman/frontend/src/components/tableHeaders/PresentationListHeaders.js
+++ b/services/bb-pacman/frontend/src/components/tableHeaders/PresentationListHeaders.js
@@ -2,7 +2,7 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 */
 
@@ -26,5 +26,19 @@ export const presentationListHeaders = [
   {
     text: " ",
     value: "actions",
+  },
+];
+export const issuedListHeaders = [
+  {
+    text: "Type",
+    value: "type",
+  },
+  {
+    text: "Issued At",
+    value: "issuedAt",
+  },
+  {
+    text: "State",
+    value: "state",
   },
 ];

--- a/services/bb-pacman/frontend/src/main.js
+++ b/services/bb-pacman/frontend/src/main.js
@@ -25,7 +25,8 @@ Vue.use(SortUtil);
 
 
 var apiBaseUrl = process.env.VUE_APP_API_BASE_URL;
-var socketApi = `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/${process.env.VUE_APP_EVENTS_PATH}`;
+var eventsHost = process.env.VUE_APP_EVENTS_HOST ? process.env.VUE_APP_EVENTS_HOST : window.location.host;
+var socketApi = `${window.location.protocol === "https:" ? "wss" : "ws"}://${eventsHost}/${process.env.VUE_APP_EVENTS_PATH}`;
 
 if (process.env.NODE_ENV === "development") {
   store.commit({
@@ -108,6 +109,7 @@ export { EventBus, axios, apiBaseUrl };
 console.log(Vue.prototype);
 store.dispatch("loadSettings");
 store.dispatch("loadSchemas");
+store.dispatch("loadCredDefs");
 
 new Vue({
   vuetify,

--- a/services/bb-pacman/frontend/src/router/index.js
+++ b/services/bb-pacman/frontend/src/router/index.js
@@ -29,6 +29,8 @@ import AddSchema from "../views/AddSchema.vue";
 import CreateSchema from "../views/CreateSchema.vue";
 import CreateCredDef from "../views/CreateCredDef.vue";
 import About from "../views/About.vue";
+import IssueCredential from "../views/IssueCredential.vue"
+import IssuedCredentialPresentation from "../views/IssuedCredentialPresentation.vue"
 
 Vue.use(VueRouter);
 
@@ -91,6 +93,12 @@ const routes = [
     props: true,
   },
   {
+    path: "/app/partners/:id/issued/:credId",
+    name: "IssuedCredentialPresentation",
+    component: IssuedCredentialPresentation,
+    props: true,
+  },
+  {
     path: "/app/partners",
     name: "Partners",
     component: Partners,
@@ -111,6 +119,12 @@ const routes = [
     path: "/app/partners/:id/send",
     name: "SendPresentation",
     component: SendPresentation,
+    props: true,
+  },
+  {
+    path: "/app/partners/:id/issue",
+    name: "IssueCredential",
+    component: IssueCredential,
     props: true,
   },
   {

--- a/services/bb-pacman/frontend/src/router/index.js
+++ b/services/bb-pacman/frontend/src/router/index.js
@@ -27,6 +27,7 @@ import SchemaSettings from "../views/SchemaSettings.vue";
 import Schema from "../views/Schema.vue";
 import AddSchema from "../views/AddSchema.vue";
 import CreateSchema from "../views/CreateSchema.vue";
+import CreateCredDef from "../views/CreateCredDef.vue";
 import About from "../views/About.vue";
 
 Vue.use(VueRouter);
@@ -136,6 +137,12 @@ const routes = [
     path: "/app/schema/create",
     name: "CreateSchema",
     component: CreateSchema,
+  },
+  {
+    path: "/app/creddef/create",
+    name: "CreateCredDef",
+    component: CreateCredDef,
+    props: true,
   },
   {
     path: "/app/schema/:id",

--- a/services/bb-pacman/frontend/src/store/actions.js
+++ b/services/bb-pacman/frontend/src/store/actions.js
@@ -30,6 +30,22 @@ export const loadSchemas = async ({ commit }) => {
     });
 };
 
+export const loadCredDefs = async ({ commit }) => {
+  axios
+    .get(`${apiBaseUrl}/admin/creddef?map=true`)
+    .then((result) => {
+      let creddefs = result.data;
+      commit({
+        type: "setCredDefs",
+        creddefs: creddefs,
+      });
+    })
+    .catch((e) => {
+      console.error(e);
+      EventBus.$emit("error", e);
+    });
+};
+
 export const loadPartners = async ({ commit }) => {
   axios
     .get(`${apiBaseUrl}/partners`)

--- a/services/bb-pacman/frontend/src/store/getters.js
+++ b/services/bb-pacman/frontend/src/store/getters.js
@@ -29,6 +29,10 @@ export const getSchemas = (state) => {
   return state.schemas;
 };
 
+export const getCredDefs = (state) => {
+  return state.credDefs;
+};
+
 export const getSchemaById = (state) => (schemaId) => {
   if (!schemaId) {
     return null;
@@ -36,6 +40,14 @@ export const getSchemaById = (state) => (schemaId) => {
   return state.schemas.find((schema) => {
     return schema.schemaId === schemaId;
   });
+};
+
+export const getSchemaCredDef = (state) => (schemaId) => {
+  const s = getSchemaById(schemaId);
+  if (!s) {
+    return null;
+  }
+  return state.credDefs[s.schemaId];
 };
 
 export const getSchemaByType = (state) => (schemaType) => {

--- a/services/bb-pacman/frontend/src/store/index.js
+++ b/services/bb-pacman/frontend/src/store/index.js
@@ -2,7 +2,7 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 */
 
@@ -22,6 +22,7 @@ const store = new Vuex.Store({
     documents: [],
     credentials: [],
     schemas: [],
+    credDefs: {},
     busyStack: 0,
     expertMode: false,
     settings: {},
@@ -42,6 +43,9 @@ const store = new Vuex.Store({
     },
     setSchemas(state, payload) {
       state.schemas = payload.schemas;
+    },
+    setCredDefs(state, payload) {
+      state.credDefs = payload.credDefs;
     },
     setExpertMode(state, payload) {
       state.expertMode = payload.isExpert;

--- a/services/bb-pacman/frontend/src/views/AddSchema.vue
+++ b/services/bb-pacman/frontend/src/views/AddSchema.vue
@@ -96,7 +96,7 @@ export default {
       this.isBusyAddSchema = true;
 
       this.$axios
-        .post(`${this.$apiBaseUrl}/admin/schema`, this.schema)
+        .post(`${this.$apiBaseUrl}/admin/schema/import`, this.schema)
         .then((result) => {
           console.log(result);
           this.isBusyAddSchema = false;

--- a/services/bb-pacman/frontend/src/views/CreateCredDef.vue
+++ b/services/bb-pacman/frontend/src/views/CreateCredDef.vue
@@ -1,0 +1,170 @@
+<!--
+ Copyright (c) 2020 - for information on the respective copyright owner
+ see the NOTICE file and/or the repository at
+ https://github.com/hyperledger-labs/organizational-agent
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+<template>
+  <v-container>
+    <v-card max-width="600" class="mx-auto">
+      <v-card-title class="bg-light">
+        <v-btn depressed color="secondary" icon @click="$router.go(-1)">
+          <v-icon dark>mdi-chevron-left</v-icon>
+        </v-btn>
+        <span>Create Credential Definition</span>
+      </v-card-title>
+      <v-list-item>
+        <v-list-item-title class="grey--text text--darken-2 font-weight-medium">
+          Schema Id:
+        </v-list-item-title>
+        <v-list-item-subtitle>
+          <v-text-field
+            class="mt-6"
+            placeholder="Schema Id"
+            v-model="schemaId"
+            :rules="[rules.required]"
+            outlined
+            dense
+            required
+            readonly
+            disabled
+          >
+          </v-text-field>
+        </v-list-item-subtitle>
+      </v-list-item>
+      <v-list-item>
+        <v-list-item-title class="grey--text text--darken-2 font-weight-medium">
+          Tag:
+        </v-list-item-title>
+        <v-list-item-subtitle>
+          <v-text-field
+            class="mt-6"
+            placeholder="Tag"
+            v-model="tag"
+            :rules="[rules.required,rules.schemaText]"
+            outlined
+            dense
+            required
+          >
+          </v-text-field>
+        </v-list-item-subtitle>
+      </v-list-item>
+      <v-list-item>
+        <v-list-item-title class="grey--text text--darken-2 font-weight-medium">
+          Revocation Registry Size:
+        </v-list-item-title>
+        <v-list-item-subtitle>
+          <v-text-field
+            class="mt-6"
+            placeholder="Revocation Registry Size (integer)"
+            v-model="revocationRegistrySize"
+            :rules="[rules.required, rules.sized]"
+            outlined
+            dense
+            required
+            disabled
+          >
+          </v-text-field>
+        </v-list-item-subtitle>
+      </v-list-item>
+      <v-list-item>
+        <v-list-item-title class="grey--text text--darken-2 font-weight-medium">
+        </v-list-item-title>
+        <v-list-item-subtitle>
+          <v-checkbox
+            class="mt-6"
+            label="Support Revocation"
+            v-model="supportRevocation"
+            outlined
+            dense
+            disabled
+          >
+          </v-checkbox>
+        </v-list-item-subtitle>
+      </v-list-item>
+      <v-card-actions>
+        <v-layout justify-end>
+          <v-btn
+            :loading="this.isBusyCreateCredDef"
+            :disabled="fieldsEmpty"
+            color="primary"
+            @click="createCredDef"
+          >
+            Submit
+          </v-btn>
+        </v-layout>
+      </v-card-actions>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+  import { EventBus } from "../main";
+  export default {
+    name: "CreateCredDef",
+    props: {
+      schemaId: String
+    },
+    components: {},
+    created: () => {
+    },
+    data: () => {
+      return {
+        credDef: undefined,
+        tag: "default",
+        supportRevocation: false,
+        revocationRegistrySize: 4,
+        isBusyCreateCredDef: false,
+        rules: {
+          required: (value) => !!value || "Can't be empty",
+          sized: (value) => (value && /^\d+$/.test(value) && (value >= 4 && value <= 32768)) || "Size must be integer between 4 and 32768",
+          schemaText: (value) => (value && /^[a-zA-Z\d-_]+$/.test(value)) || "Value must be alphanumeric and '_' or '-'"
+        }
+      };
+    },
+    computed: {
+      fieldsEmpty() {
+        return (
+          this.schemaId.length === 0 || this.tag.length === 0 || this.revocationRegistrySize < 4 || this.revocationRegistrySize > 32768
+        );
+      },
+    },
+    methods: {
+      fixParams(s) {
+        return s.trim().replace(/ /g, "_");
+      },
+      createCredDef() {
+        this.isBusyCreateCredDef = true;
+
+        const data = {
+          schemaId: this.schemaId,
+          tag: this.fixParams(this.tag),
+          supportRevocation: this.supportRevocation,
+          revocationRegistrySize: this.revocationRegistrySize
+        };
+
+        this.$axios
+          .post(`${this.$apiBaseUrl}/admin/creddef`, data)
+          .then((result) => {
+            this.isBusyCreateCredDef = false;
+
+            if (result.status === 200 || result.status === 200) {
+              EventBus.$emit("success", "Credential Definition created successfully");
+              this.$store.dispatch("loadSchemas");
+              this.$store.dispatch("loadCredDefs");
+              this.$router.go(-1);
+            }
+          })
+          .catch((e) => {
+            this.isBusyCreateCredDef = false;
+            if (e.response.status === 400) {
+              EventBus.$emit("error", "Credential Definition already exists");
+            } else {
+              EventBus.$emit("error", e);
+            }
+          });
+      },
+    },
+  };
+</script>

--- a/services/bb-pacman/frontend/src/views/CreateSchema.vue
+++ b/services/bb-pacman/frontend/src/views/CreateSchema.vue
@@ -7,81 +7,113 @@
 -->
 <template>
   <v-container>
-    <v-card max-width="600" class="mx-auto">
+    <v-card class="mx-auto">
       <v-card-title class="bg-light">
         <v-btn depressed color="secondary" icon @click="$router.go(-1)">
           <v-icon dark>mdi-chevron-left</v-icon>
         </v-btn>
         <span>Create Schema</span>
       </v-card-title>
-      <v-list-item>
-        <v-list-item-title class="grey--text text--darken-2 font-weight-medium">
-          Schema Label:
-        </v-list-item-title>
-        <v-list-item-subtitle>
-          <v-text-field
-            class="mt-6"
-            placeholder="Label"
-            v-model="schemaLabel"
-            :rules="[rules.required]"
-            outlined
-            dense
-            required
-          >
-          </v-text-field>
-        </v-list-item-subtitle>
-      </v-list-item>
-      <v-list-item>
-        <v-list-item-title class="grey--text text--darken-2 font-weight-medium">
-          Schema Name:
-        </v-list-item-title>
-        <v-list-item-subtitle>
-          <v-text-field
-            class="mt-6"
-            placeholder="Name"
-            v-model="schemaName"
-            :rules="[rules.required,rules.schemaText]"
-            outlined
-            dense
-            required
-          >
-          </v-text-field>
-        </v-list-item-subtitle>
-      </v-list-item>
-      <v-list-item>
-        <v-list-item-title class="grey--text text--darken-2 font-weight-medium">
-          Schema Version:
-        </v-list-item-title>
-        <v-list-item-subtitle>
-          <v-text-field
-            class="mt-6"
-            placeholder="0.0.0"
-            v-model="schemaVersion"
-            :rules="[rules.required, rules.version]"
-            outlined
-            dense
-            required
-          >
-          </v-text-field>
-        </v-list-item-subtitle>
-      </v-list-item>
-      <v-list-item>
-        <v-list-item-title class="grey--text text--darken-2 font-weight-medium">
-          Attributes:
-        </v-list-item-title>
-        <v-list-item-subtitle>
-          <v-text-field
-            class="mt-6"
-            placeholder="Comma separated attribute names"
-            v-model="schemaAttributes"
-            :rules="[rules.required]"
-            outlined
-            dense
-            required
-          >
-          </v-text-field>
-        </v-list-item-subtitle>
-      </v-list-item>
+      <v-container>
+        <v-row>
+          <v-col cols="4" class="pb-0">
+            <p class="grey--text text--darken-2 font-weight-medium">
+              Schema Information
+            </p>
+          </v-col>
+          <v-col cols="8" class="pb-0">
+            <v-text-field
+              label="Schema Label"
+              placeholder="Label in your application for this schema"
+              v-model="schemaLabel"
+              :rules="[rules.required]"
+              outlined
+              dense
+            ></v-text-field>
+            <v-text-field
+              label="Schema Name"
+              placeholder="Published schema name (ex. my-schema)"
+              v-model="schemaName"
+              :rules="[rules.required, rules.schemaText]"
+              required
+              outlined
+              dense
+            ></v-text-field>
+            <v-text-field
+              label="Schema Version"
+              placeholder="Published schema version (ex. 1.2 or 1.2.3)"
+              v-model="schemaVersion"
+              :rules="[rules.required, rules.version]"
+              required
+              outlined
+              dense
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4" class="pb-0">
+            <p class="grey--text text--darken-2 font-weight-medium">
+              Schema Attributes
+            </p>
+          </v-col>
+          <v-col cols="8" class="pb-0">
+            <v-row>
+              <v-col class="py-0"><p class="grey--text">
+                Name
+              </p></v-col>
+              <v-col cols="4" class="py-0"><p class="grey--text">
+                Is Default
+              </p></v-col>
+              <v-col cols="2" class="py-0"><p class="grey--text">
+                Action
+              </p>
+              </v-col>
+            </v-row>
+          <v-row
+              v-for="(attr, index) in schemaAttributes"
+              v-bind:key="attr.type"
+            >
+              <v-col class="py-0">
+                <v-text-field
+                  placeholder="Ex. companyName or company-name"
+                  v-model="attr.text"
+                  :rules="[rules.required, rules.schemaText]"
+                  outlined
+                  dense
+                ></v-text-field>
+              </v-col>
+              <v-col cols="4" class="py-0">
+                <v-checkbox
+                  v-model="attr.defaultAttribute"
+                  outlined
+                  dense
+                  style="margin-top: 4px;padding-top: 4px;"
+                  @change="makeDefaultAttribute(index, attr.defaultAttribute)"
+                ></v-checkbox>
+              </v-col>
+              <v-col cols="2" class="py-0">
+                <v-layout>
+                  <v-btn
+                    v-if="index === schemaAttributes.length - 1"
+                    icon
+                    text
+                    @click="addAttribute"
+                  >
+                    <v-icon color="primary">mdi-plus</v-icon></v-btn>
+                  <v-btn
+                    icon
+                    v-if="index !== schemaAttributes.length - 1"
+                    @click="deleteAttribute(index)"
+                  >
+                    <v-icon color="error">mdi-delete</v-icon>
+                  </v-btn>
+                </v-layout>
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-row>
+      </v-container>
+      <v-divider></v-divider>
       <v-card-actions>
         <v-layout justify-end>
           <v-btn
@@ -103,19 +135,20 @@ import { EventBus } from "../main";
 export default {
   name: "CreateSchema",
   components: {},
-  created: () => {},
+  created: () => {
+  },
   data: () => {
     return {
-      schema: undefined,
       schemaLabel: "",
       schemaName: "",
       schemaVersion: "",
-      schemaAttributes: "",
+      schemaAttributeText: "",
+      schemaAttributes: [{defaultAttribute: true, text: ""}],
       isBusyCreateSchema: false,
       rules: {
         required: (value) => !!value || "Can't be empty",
-        version: (value) => (value && /^\d+(\.\d+){0,2}$/.test(value)) || "Schema Version must be numbers and '.'",
-        schemaText: (value) => (value && /^[a-zA-Z\d-_]+$/.test(value)) || "Schema name and attributes must be alphanumeric and '_' or '-'"
+        version: (value) => (value && /^(\d+)\.(\d+)(?:\.\d+)?$/.test(value)) || "Must be follow common version numbering (ex. 1.2 or 1.2.3)",
+        schemaText: (value) => (value && /^[a-zA-Z\d-_]+$/.test(value)) || "Must be alphanumeric with optional '_' or '-'"
       }
     };
   },
@@ -124,26 +157,42 @@ export default {
       return (
         this.schemaLabel.length === 0 || this.schemaName.length === 0 || this.schemaVersion.length === 0 || this.schemaAttributes.length === 0
       );
-    },
+    }
   },
   methods: {
+    makeDefaultAttribute(idx, val) {
+      // if setting true, set all others to false...
+      if (val) {
+        this.schemaAttributes.forEach((v,i) => v.defaultAttribute = idx === i);
+      }
+    },
+    addAttribute() {
+      this.schemaAttributes.push({
+        defaultAttribute: false,
+        text: "",
+      });
+    },
+    deleteAttribute(i) {
+      this.schemaAttributes.splice(i, 1);
+    },
     fixSchemaParams(s) {
       return s.trim().replace(/ /g, "_");
     },
     createSchema() {
       this.isBusyCreateSchema = true;
 
-      const attrs = this.schemaAttributes.split(",").map(s => this.fixSchemaParams(s));
-
+      const attrs = this.schemaAttributes.filter(x => x.text.trim().length).map(x => this.fixSchemaParams(x.text));
+      const defaultAttr = this.schemaAttributes.find(x => x.defaultAttribute);
       const data = {
         schemaLabel: this.schemaLabel,
         schemaName: this.fixSchemaParams(this.schemaName),
         schemaVersion: this.fixSchemaParams(this.schemaVersion),
-        attributes: attrs
+        attributes: attrs,
+        defaultAttributeName: defaultAttr ? defaultAttr.text : undefined
       };
 
       this.$axios
-        .post(`${this.$apiBaseUrl}/admin/schema/create`, data)
+        .post(`${this.$apiBaseUrl}/admin/schema`, data)
         .then((result) => {
           this.isBusyCreateSchema = false;
 

--- a/services/bb-pacman/frontend/src/views/IssueCredential.vue
+++ b/services/bb-pacman/frontend/src/views/IssueCredential.vue
@@ -1,0 +1,216 @@
+<!--
+ Copyright (c) 2020 - for information on the respective copyright owner
+ see the NOTICE file and/or the repository at
+ https://github.com/hyperledger-labs/organizational-agent
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+<template>
+  <v-container>
+    <v-card class="mx-auto">
+      <v-card-title class="bg-light">
+        <v-btn depressed color="secondary" icon @click="$router.go(-1)">
+          <v-icon dark>mdi-chevron-left</v-icon>
+        </v-btn>
+        Issue a Credential
+      </v-card-title>
+
+      <v-card-text>
+        <h4 class="pt-4">Select a credential to issue</h4>
+        <v-combobox
+          v-model="selectedSchema"
+          :items="schemaList"
+          label=""
+          outlined
+          dense
+          @change="schemaSelected"
+        ></v-combobox>
+      </v-card-text>
+
+      <v-card-text>
+      <h4 v-if="selectedSchema && selectedSchema.value && selectedSchema.value.schema">Credential Content</h4>
+      <v-row>
+        <v-col>
+          <v-text-field
+            v-for="field in selectedSchema.value.fields"
+            :key="field.type"
+            :label="field.label"
+            placeholder
+            :rules="[(v) => !!v || 'Item is required']"
+            :required="field.required"
+            outlined
+            dense
+            @change="fieldChanged(field.type, $event)"
+          ></v-text-field>
+        </v-col>
+      </v-row>
+      </v-card-text>
+      <v-card-actions>
+        <v-layout align-end justify-end>
+          <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
+          <v-btn
+            :loading="this.isBusy"
+            color="primary"
+            text
+            @click="issueCredential()"
+            :disabled="fieldsEmpty"
+          >Submit</v-btn
+          >
+        </v-layout>
+      </v-card-actions>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+  import { EventBus } from "../main";
+
+  // import { CredentialTypes } from "../constants";
+  //import MyCredentialList from "@/components/MyCredentialList";
+
+  export default {
+    name: "IssueCredential",
+    components: {
+      //MyCredentialList,
+    },
+    props: {
+      id: String,
+    },
+    created() {
+      EventBus.$emit("title", "Issue Credential");
+      this.getSchemaList();
+    },
+    data: () => {
+      return {
+        isBusy: false,
+        schemaList: [],
+        selectedSchema: {text: '', value: {}},
+        credentialFields: {},
+        fieldsEmpty: true,
+        credHeaders: [
+          {
+            text: "Label",
+            value: "label",
+          },
+          {
+            text: "Type",
+            value: "type",
+          },
+          {
+            text: "Issuer",
+            value: "issuer",
+          },
+          {
+            text: "Issued at",
+            value: "issuedAt",
+          },
+        ],
+      };
+    },
+    computed: {
+
+    },
+    methods: {
+      getSchemaList() {
+        // get schemas...
+        // get cred defs
+        // map together for  pick list
+        var _schemas = [];
+        var _creddefs = {};
+        this.schemaList = [];
+        this.$axios
+          .get(`${this.$apiBaseUrl}/admin/schema`)
+          .then((result) => {
+            if ({}.hasOwnProperty.call(result, "data")) {
+              _schemas = result.data;
+            }
+          })
+          .then(() => { return this.$axios.get(`${this.$apiBaseUrl}/admin/creddef?map=true`) })
+          .then((result) => {
+            if ({}.hasOwnProperty.call(result, "data")) {
+              _creddefs = result.data;
+            }
+            _schemas.forEach(d => {
+              const cdef = _creddefs[d.schemaId];
+              if (cdef) {
+                const o = {
+                  text: `${d.label} (${d.schemaId.split(':').reverse()[0]})`,
+                  value: {
+                    schema: d,
+                    creddef: cdef,
+                    fields: d.schemaAttributeNames.map((key) => {
+                      return {
+                        type: key,
+                        label: key
+                          ? key.substring(0, 1).toUpperCase() +
+                          key.substring(1).replace(/([a-z])([A-Z])/g, "$1 $2")
+                          : "",
+                      };
+                    })
+                  }
+                }
+                this.schemaList.push(o);
+              }
+            });
+            this.isBusy = false;
+          })
+          .catch((e) => {
+            this.isBusy = false;
+            if (e.response.status === 404) {
+              this.schemaList = [];
+            } else {
+              console.error(e);
+              EventBus.$emit("error", e);
+            }
+          });
+      },
+
+      schemaSelected() {
+        this.credentialFields = {};
+        this.fieldsEmpty = true;
+      },
+
+      fieldChanged(propertyName, event) {
+        this.credentialFields[propertyName] = event;
+        this.fieldsEmpty = !(event && event.trim().length> 0);
+      },
+      issueCredential() {
+        this.isBusy = true;
+        this.$axios
+          .post(`${this.$apiBaseUrl}/partners/${this.id}/issue-credential/send`, {
+            schemaId: this.selectedSchema.value.schema.schemaId,
+            credentialDefinitionId: this.selectedSchema.value.creddef.id,
+            document: this.credentialFields
+          })
+          .then((res) => {
+            console.log(res);
+            this.isBusy = false;
+            EventBus.$emit("success", "Credential Issued");
+            this.$router.push({
+              name: "Partner",
+              params: { id: this.id },
+            });
+          })
+          .catch((e) => {
+            this.isBusy = false;
+            console.error(e);
+            EventBus.$emit("error", e);
+          });
+      },
+
+      cancel() {
+        this.$router.go(-1);
+      },
+    },
+  };
+</script>
+
+<style scoped>
+  .bg-light {
+    background-color: #fafafa;
+  }
+
+  .bg-light-2 {
+    background-color: #ececec;
+  }
+</style>

--- a/services/bb-pacman/frontend/src/views/IssuedCredentialPresentation.vue
+++ b/services/bb-pacman/frontend/src/views/IssuedCredentialPresentation.vue
@@ -1,0 +1,114 @@
+<!--
+ Copyright (c) 2020 - for information on the respective copyright owner
+ see the NOTICE file and/or the repository at
+ https://github.com/hyperledger-labs/organizational-agent
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+<template>
+  <v-container>
+    <v-card v-if="isReady" class="mx-auto">
+      <v-card-title class="bg-light">
+        <v-btn depressed color="secondary" icon @click="$router.go(-1)">
+          <v-icon dark>mdi-chevron-left</v-icon>
+        </v-btn>
+        <div v-if="presentation.type === CredentialTypes.UNKNOWN.type">
+          {{ presentation.credentialDefinitionId | credentialTag }}
+        </div>
+        <div v-else>
+          {{ presentation.typeLabel }}
+        </div>
+      </v-card-title>
+      <v-card-text>
+        <Cred v-bind:document="presentation" isReadOnly></Cred>
+        <v-divider></v-divider>
+      </v-card-text>
+      <v-card-actions>
+        <v-expansion-panels v-if="expertMode" accordion flat>
+          <v-expansion-panel>
+            <v-expansion-panel-header
+              class="grey--text text--darken-2 font-weight-medium bg-light"
+              >Show raw data</v-expansion-panel-header
+            >
+            <v-expansion-panel-content class="bg-light">
+              <vue-json-pretty :data="presentation"></vue-json-pretty>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-card-actions>
+
+      <!-- <v-card-actions>
+      <v-layout align-end justify-end>
+        <v-btn color="secondary" text @click="cancel()">Cancel</v-btn>
+        <v-btn :loading="this.isBusy" color="primary" text @click="saveChanges()">Save</v-btn>
+      </v-layout>
+    </v-card-actions> -->
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import { EventBus } from "../main";
+
+import Cred from "@/components/Credential";
+import { CredentialTypes } from "../constants";
+
+export default {
+  name: "IssuedCredentialPresentation",
+  props: {
+    id: String,
+    credId: String,
+  },
+  created() {
+    EventBus.$emit("title", "Issued Credential");
+    this.getPresentation();
+  },
+  data: () => {
+    return {
+      document: {},
+      isBusy: false,
+      isReady: false,
+      CredentialTypes: CredentialTypes,
+    };
+  },
+  computed: {
+    expertMode() {
+      return this.$store.state.expertMode;
+    },
+  },
+  methods: {
+    getPresentation() {
+      this.$axios
+        .get(
+          `${this.$apiBaseUrl}/partners/${this.id}/issue-credential/${this.credId}`
+        )
+        .then((result) => {
+          if ({}.hasOwnProperty.call(result, "data")) {
+            this.presentation = result.data;
+            this.isReady = true;
+          }
+        })
+        .catch((e) => {
+          console.error(e);
+          EventBus.$emit("error", e);
+        });
+    },
+    cancel() {
+      this.$router.go(-1);
+    },
+  },
+  components: {
+    Cred,
+  },
+};
+</script>
+
+<style scoped>
+.bg-light {
+  background-color: #fafafa;
+}
+
+.bg-light-2 {
+  background-color: #ececec;
+}
+</style>

--- a/services/bb-pacman/frontend/src/views/Schema.vue
+++ b/services/bb-pacman/frontend/src/views/Schema.vue
@@ -2,7 +2,7 @@
  Copyright (c) 2020 - for information on the respective copyright owner
  see the NOTICE file and/or the repository at
  https://github.com/hyperledger-labs/organizational-agent
- 
+
  SPDX-License-Identifier: Apache-2.0
 -->
 <template>
@@ -17,6 +17,20 @@
           <!-- <v-btn depressed icon @click="isUpdatingName = !isUpdatingName">
                     <v-icon dark>mdi-pencil</v-icon>
                 </v-btn> -->
+          <v-tooltip top>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn
+                color="primary"
+                v-bind="attrs"
+                v-on="on"
+                icon
+                @click="fetchCredDef()"
+              >
+                <v-icon dark>mdi-refresh</v-icon>
+              </v-btn>
+            </template>
+            <span>Refresh</span>
+          </v-tooltip>
           <v-btn
             depressed
             color="red"
@@ -50,7 +64,38 @@
             {{ attribute }}
           </p>
         </v-list-item>
+        <v-list-item class="mt-4" v-if="this.credDef">
+          <v-list-item-title
+            class="grey--text text--darken-2 font-weight-medium"
+          >
+            Credential Definition Id:
+          </v-list-item-title>
+          <v-list-item-subtitle>
+            {{ this.credDef.id }}
+          </v-list-item-subtitle>
+        </v-list-item>
       </v-container>
+      <v-card-actions v-if="!this.credDef">
+        <v-tooltip bottom>
+          <template v-slot:activator="{on, attrs}">
+            <v-btn
+              color="primary"
+              small
+              dark
+              absolute
+              bottom
+              left
+              fab
+              @click="goToCredDef()"
+              v-bind="attrs"
+              v-on="on"
+            >
+              <v-icon>mdi-plus</v-icon>
+            </v-btn>
+          </template>
+          <span>Create Credential Definition</span>
+        </v-tooltip>
+      </v-card-actions>
     </v-card>
   </v-container>
 </template>
@@ -72,15 +117,38 @@ export default {
     } else {
       this.fetch();
     }
+    this.fetchCredDef();
   },
   data: () => {
     return {
       data: [],
+      credDef: undefined,
       isLoading: true,
     };
   },
   computed: {},
   methods: {
+    fetchCredDef() {
+      this.isLoading = true;
+      this.$axios
+        .get(`${this.$apiBaseUrl}/admin/schema/${this.id}/creddef`)
+        .then((result) => {
+          console.log(result);
+          if ({}.hasOwnProperty.call(result, "data")) {
+            this.credDef = result.data;
+            this.isLoading = false;
+          }
+        })
+        .catch((e) => {
+          this.isLoading = false;
+          if (e.response.status === 404) {
+            this.credDef = undefined;
+          } else {
+            //console.error(e);
+            //EventBus.$emit("error", e);
+          }
+        });
+    },
     fetch() {
       this.isLoading = true;
       this.$axios
@@ -120,6 +188,15 @@ export default {
           EventBus.$emit("error", e);
         });
     },
+
+    goToCredDef() {
+      this.$router.push({
+        name: "CreateCredDef",
+        params: {
+          schemaId: this.schema ? this.schema.schemaId : this.data['schemaId']
+        },
+      });
+    }
   },
 };
 </script>

--- a/services/bb-pacman/frontend/src/views/SchemaSettings.vue
+++ b/services/bb-pacman/frontend/src/views/SchemaSettings.vue
@@ -80,6 +80,7 @@ export default {
   data: () => {
     return {
       data: [],
+      credDefs: {},
       newSchema: {
         label: "",
         schemaId: "",
@@ -95,10 +96,15 @@ export default {
           text: "Schema ID",
           value: "schemaId",
         },
+        {
+          text: "Cred Def ID",
+          value: "credDefId",
+        },
       ],
     };
   },
-  computed: {},
+  computed: {
+  },
   methods: {
     fetch() {
       this.$axios
@@ -106,12 +112,25 @@ export default {
         .then((result) => {
           console.log(result);
           if ({}.hasOwnProperty.call(result, "data")) {
-            this.isBusy = false;
-
             this.data = result.data;
-
             console.log(this.data);
           }
+        })
+        .then(() => { return this.$axios.get(`${this.$apiBaseUrl}/admin/creddef?map=true`) })
+        .then((result) => {
+          console.log(result);
+          if ({}.hasOwnProperty.call(result, "data")) {
+            this.credDefs = result.data;
+            console.log(this.data);
+          }
+          // pop the credential definition id in the data if exists.
+          this.data.forEach(d => {
+            const cdef = this.credDefs[d.schemaId];
+            if (cdef) {
+              d["credDefId"] = cdef.id;
+            }
+          });
+          this.isBusy = false;
         })
         .catch((e) => {
           this.isBusy = false;

--- a/services/bb-pacman/scripts/local-development/.env-example
+++ b/services/bb-pacman/scripts/local-development/.env-example
@@ -38,6 +38,9 @@ BPA_DID_PREFIX=did:sov:
 # The Ledger Explorer
 BPA_LEDGER_BROWSER=http://host.docker.internal:9000
 
+# Docker image to be used for the business partner
+BPA_DOCKER_IMAGE=ghcr.io/hyperledger-labs/business-partner-agent:local
+
 # ------------------------------------------------------------
 # ACA-PY
 # ------------------------------------------------------------

--- a/services/bb-pacman/scripts/local-development/docker-compose.yml
+++ b/services/bb-pacman/scripts/local-development/docker-compose.yml
@@ -5,6 +5,7 @@ services:
 # (Docker Backend/Frontend + agent + wallet)
 #######
   partner-app:
+    image: ${BPA_DOCKER_IMAGE}
     build:
       context: ../..
       dockerfile: Dockerfile


### PR DESCRIPTION
Having the cred def separated from the Create Schema operation allows us to create cred defs to schemas we import.  Also, it is a time consuming operation, so breaking it apart from other functions is good for visual feedback.

Was trying to do all the work WITHOUT storing anything more in the database.

Also..
Change Add Schema to to Import Schema
Add services to cache My Cred Defs
Add endpoints to match My Schemas with My Cred Defs

Signed-off-by: Jason Sherman <jsherman@parcsystems.ca>

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->